### PR TITLE
3 fix double title

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,18 +5,23 @@
 {% if home_path == "" %}
   {% assign home_path = "/" %}
 {% endif %}
+
+{% capture generated_title %}
+  {% if page.title != "Home" %}
+    {{ page.description }}, {{ page.loc }} | {{ site.title }}
+  {% else %}
+    {{ site.title }} | {{ page.tagline }}
+  {% endif %}
+{% endcapture %}
+
+{% assign generated_title = generated_title | strip %}
+
 <!doctype html>
 <html>
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>
-      {% if page.title != "Home" %}
-        {{ page.description }}, {{ page.loc }} | {{ site.title }}
-      {% else %}
-        {{ site.title }} | {{ page.tagline }}
-      {% endif %}
-    </title>
+    <title>{{ generated_title }}</title>
     <link rel="stylesheet" href="/assets/css/bootstrap.min.css">
     <link rel="stylesheet" href="/assets/css/styles.css">
     <link rel="shortcut icon" type="image/png" href="/favicon.png">
@@ -37,7 +42,7 @@
     </script>
     <meta name="yandex-verification" content="1f2279cd2a242362" />
     <link type="application/atom+xml" rel="alternate" href="https://www.maryana.design/feed/portfolio/{{page.lang}}.xml" title="Maryana.Interior.Design">
-    {% seo %}
+    {% seo title=false %}
   </head>
   <body>
     <div class="container">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,21 +1,17 @@
-{% assign t = site.data.I18n[page.lang] %}
-<!-- Set home path -->
-{% assign lang_data = site.languages | find: "code", page.lang %}
-{% assign home_path = lang_data.slug %}
-{% if home_path == "" %}
-  {% assign home_path = "/" %}
-{% endif %}
-
-{% capture generated_title %}
-  {% if page.title != "Home" %}
+{% assign t = site.data.I18n[page.lang] -%}
+{% assign lang_data = site.languages | find: "code", page.lang -%}
+{% assign home_path = lang_data.slug -%}
+{% if home_path == "" -%}
+  {% assign home_path = "/" -%}
+{% endif -%}
+{% capture generated_title -%}
+  {% if page.title != "Home" -%}
     {{ page.description }}, {{ page.loc }} | {{ site.title }}
-  {% else %}
+  {% else -%}
     {{ site.title }} | {{ page.tagline }}
-  {% endif %}
-{% endcapture %}
-
-{% assign generated_title = generated_title | strip %}
-
+  {% endif -%}
+{% endcapture -%}
+{% assign generated_title = generated_title | strip -%}
 <!doctype html>
 <html>
   <head>


### PR DESCRIPTION
# Fix double title

1. **feat(title): title generation strip symbols** 

Исправил генерацию заголовка: убрал все пустые символы. Если заголовок длинный, в консоле будет видно как будто он стоит в кавычках "". Чтобы посмотреть как на самом деле выглядит страница, нужно в браузере выбрать "Просмотр кода страницы".

2. **fix(title): removed second title generation**

Убрал генерацию второго заголовка страницы

3. **chore(layout): removed empty space at the html beginning**

Убрал пустые строки в начале html (в принципе ничего страшного, но лучше убрать). html до/после:

![Снимок экрана 2024-04-18 в 18 31 16](https://github.com/150years/maryana.design/assets/69132749/98fd6fcc-cf7d-4530-90bd-f0c721605415)
![Снимок экрана 2024-04-18 в 18 30 36](https://github.com/150years/maryana.design/assets/69132749/2df660aa-4b53-4cf4-a680-0ab4711c4eaa)
